### PR TITLE
v5.3.7 - handle applications mounted on /pathName routes

### DIFF
--- a/cleaner/assets/javascripts/application.js
+++ b/cleaner/assets/javascripts/application.js
@@ -94,6 +94,7 @@ $(function() {
 $(function() {
   var authTokens = $('[name="authenticity_token"]');
   var authToken = '';
+  var nestedRoot = window.location.pathname.split('/')
   if(authTokens) {
     authToken = authTokens[0].value;
   }
@@ -101,72 +102,140 @@ $(function() {
   $('.class-cleaner-retry-button').click(function(event){
     event.preventDefault();
     var className = this.getAttribute('data_name');
-    $.ajax({
-      url: '/cleaner/errors/retry',
-      type: 'POST',
-      data: {
-        "retry_error_class": className
-      },
-      headers: {
-        "X-CSRF-Token": authToken
-      },
-      success: function(data, statusCode) {
-        window.location.href = '/cleaner/morgue'
-      }
-    });
+    if (nestedRoot.length >= 2 && nestedRoot !== '') {
+      var initialPath = nestedRoot[1]
+      $.ajax({
+        url: `/${initialPath}/cleaner/errors/retry`,
+        type: 'POST',
+        data: {
+          "retry_error_class": className
+        },
+        headers: {
+          "X-CSRF-Token": authToken
+        },
+        success: function(data, statusCode) {
+          window.location.href = '/cleaner/morgue'
+        }
+      });
+    } else {
+      $.ajax({
+        url: '/cleaner/errors/retry',
+        type: 'POST',
+        data: {
+          "retry_error_class": className
+        },
+        headers: {
+          "X-CSRF-Token": authToken
+        },
+        success: function(data, statusCode) {
+          window.location.href = '/cleaner/morgue'
+        }
+      });
+    }
   });
 
   $('.class-cleaner-delete-button').click(function(event){
     event.preventDefault();
     var className = this.getAttribute('data_name');
-    $.ajax({
-      url: '/cleaner/errors/delete',
-      type: 'POST',
-      data: {
-        "delete_error_class": className
-      },
-      headers: {
-        "X-CSRF-Token": authToken
-      },
-      success: function(data, statusCode) {
-        window.location.href = '/cleaner/morgue'
-      }
-    });
+    if (nestedRoot.length >= 2 && nestedRoot !== '') {
+      var initialPath = nestedRoot[1]
+      $.ajax({
+        url: `/${initialPath}/cleaner/errors/delete`,
+        type: 'POST',
+        data: {
+          "delete_error_class": className
+        },
+        headers: {
+          "X-CSRF-Token": authToken
+        },
+        success: function(data, statusCode) {
+          window.location.href = '/cleaner/morgue'
+        }
+      });
+    } else {
+      $.ajax({
+        url: '/cleaner/errors/delete',
+        type: 'POST',
+        data: {
+          "delete_error_class": className
+        },
+        headers: {
+          "X-CSRF-Token": authToken
+        },
+        success: function(data, statusCode) {
+          window.location.href = '/cleaner/morgue'
+        }
+      });
+    }
   });
 
   $('.exception-cleaner-retry-button').click(function(event){
     event.preventDefault();
     var exceptionName = this.getAttribute('data_name');
-    $.ajax({
-      url: '/cleaner/errors/retry',
-      type: 'POST',
-      data: {
-        "retry_error_exception": exceptionName
-      },
-      headers: {
-        "X-CSRF-Token": authToken
-      },
-      success: function(data, statusCode) {
-        window.location.href = '/cleaner/morgue'
-      }
-    });
+    if (nestedRoot.length >= 2 && nestedRoot !== '') {
+      var initialPath = nestedRoot[1];
+      $.ajax({
+        url: `/${initialPath}/cleaner/errors/retry`,
+        type: 'POST',
+        data: {
+          "retry_error_exception": exceptionName
+        },
+        headers: {
+          "X-CSRF-Token": authToken
+        },
+        success: function(data, statusCode) {
+          window.location.href = '/cleaner/morgue'
+        }
+      });
+    } else {
+      $.ajax({
+        url: '/cleaner/errors/retry',
+        type: 'POST',
+        data: {
+          "retry_error_exception": exceptionName
+        },
+        headers: {
+          "X-CSRF-Token": authToken
+        },
+        success: function(data, statusCode) {
+          window.location.href = '/cleaner/morgue'
+        }
+      });
+    }
   });
 
   $('.exception-cleaner-delete-button').click(function(event){
     event.preventDefault();
     var exceptionName = this.getAttribute('data_name');
-    $.ajax({
-      url: '/cleaner/errors/delete',
-      type: 'POST',
-      data: {
-        "delete_error_exception": expceptionName
-      },
-      headers: {
-        "X-CSRF-Token": authToken
-      },
-      success: function(data, statusCode) {
-        window.location.href = '/cleaner/morgue'
-      }
-    });
+    if (nestedRoot.length >= 2 && nestedRoot !== '') {
+      var initialPath = nestedRoot[1];
+      $.ajax({
+        url: `/${initialPath}/cleaner/errors/delete`,
+        type: 'POST',
+        data: {
+          "delete_error_exception": expceptionName
+        },
+        headers: {
+          "X-CSRF-Token": authToken
+        },
+        success: function(data, statusCode) {
+          window.location.href = '/cleaner/morgue'
+        }
+      });
+    } else {
+      $.ajax({
+        url: '/cleaner/errors/delete',
+        type: 'POST',
+        data: {
+          "delete_error_exception": expceptionName
+        },
+        headers: {
+          "X-CSRF-Token": authToken
+        },
+        success: function(data, statusCode) {
+          window.location.href = '/cleaner/morgue'
+        }
+      });
+    }
   });
 });

--- a/lib/sidekiq/version.rb
+++ b/lib/sidekiq/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sidekiq
-  VERSION = "5.3.6"
+  VERSION = "5.3.7"
 end


### PR DESCRIPTION
Site Service cannot respond to the event listener, as the application is mounted on `/sites`. Added some logic to the dashboardJS to handle retries and deletes when an application follows this route naming convention.